### PR TITLE
Corrects a bug on portuguese yt

### DIFF
--- a/correctPause.js
+++ b/correctPause.js
@@ -6,7 +6,8 @@ window.onkeydown = keyDownHandler;
 let latestAction;
 
 // Elements on which if focused pressing space won't play/pause the video
-let forbiddenElements = ['ytd-searchbox', 'contenteditable-root']
+let forbiddenElements = ['ytd-searchbox', 'contenteditable-root', 'gsfi ytd-searchbox', 'style-scope yt-formatted-string', 'search']
+
 
 // Determines if play/pause is allowed (e.g: when typing in search or comments)
 function isSpaceAllowed() {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Correct Pause",
-    "version": "1.3",
+    "version": "1.4",
 
     "permissions": [
       "*://youtube.com/*"


### PR DESCRIPTION
On portuguese yt, the input-text classes from comments are named differe